### PR TITLE
MDL-80816 core: Bump actions to newer versions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checking out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configuring node & npm
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
 
@@ -106,7 +106,7 @@ jobs:
           coverage: none
 
       - name: Checking out code from ${{ env.GITHUB_REF_SLUG }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setting up PHPUnit
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,10 +21,10 @@ jobs:
           git config --global core.eol lf
 
       - name: Checking out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configuring node & npm
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
 
@@ -59,7 +59,7 @@ jobs:
             db: pgsql
             extensions: exif, fileinfo, gd, intl, pgsql, mysql, redis, soap, sodium, zip
           - os: windows-latest
-            php: 8.0
+            php: 8.1
             db: pgsql
             extensions: exif, fileinfo, gd, intl, pgsql, mysql, redis, soap, sodium
 
@@ -117,7 +117,7 @@ jobs:
           git config --global core.eol lf
 
       - name: Checking out code from ${{ env.GITHUB_REF_SLUG }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Needs to be done after php is available, git configured and Moodle checkout has happened.
       - name: Setting up moodle-exttests service


### PR DESCRIPTION
All the new ones are Nodejs 20 based, because
Nodejs 16 is being deprecated @ GH environments.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20

Also, bump PHP version from 8.0 to 8.1, because it's a new requirement for Moodle 4.4, and it was not modified originally.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
