### PR TITLE
MDL-80819 install: halt any install if php min version is not met

### DIFF
--- a/lib/phpminimumversionlib.php
+++ b/lib/phpminimumversionlib.php
@@ -48,8 +48,8 @@ function moodle_minimum_php_version_is_met($haltexecution = false) {
     // PLEASE NOTE THIS FUNCTION MUST BE COMPATIBLE WITH OLD UNSUPPORTED VERSIONS OF PHP.
     // Do not use modern php features or Moodle convenience functions (e.g. localised strings).
 
-    $minimumversion = '7.1.0';
-    $moodlerequirementchanged = '3.7';
+    $minimumversion = '8.1.0';
+    $moodlerequirementchanged = '4.4';
 
     if (version_compare(PHP_VERSION, $minimumversion) < 0) {
         if ($haltexecution) {


### PR DESCRIPTION
Apart from environmental stuff, the moodle_minimum_php_version_is_met() function is executed by all installs (web, cli, database, ...) and halts any installation (early) not meeting the PHP constraints.

