### PR TITLE
TEST: Open PR #1

### DIFF
--- a/lib/phpunit/classes/database_driver_testcase.php
+++ b/lib/phpunit/classes/database_driver_testcase.php
@@ -142,6 +142,13 @@ abstract class database_driver_testcase extends base_testcase {
         try {
             parent::runBare();
 
+            // Deal with any debugging messages.
+            $debugerror = phpunit_util::display_debugging_messages(true);
+            $this->resetDebugging();
+            if (!empty($debugerror)) {
+                trigger_error('Unexpected debugging() call detected.' . "\n" . $debugerror, E_USER_NOTICE);
+            }
+
         } catch (Exception $ex) {
             $e = $ex;
         } catch (Throwable $ex) {

--- a/lib/phpunit/classes/util.php
+++ b/lib/phpunit/classes/util.php
@@ -690,8 +690,29 @@ class phpunit_util extends testing_util {
         // we need normal debugging outside of tests to find problems in our phpunit integration.
         $backtrace = debug_backtrace();
 
+        // Only for advanced_testcase, database_driver_testcase (and descendants). Others aren't
+        // able to manage the debugging sink, so any debugging has to be output normally and, hopefully,
+        // PHPUnit execution will catch that unexpected output properly.
+        $sinksupport = false;
         foreach ($backtrace as $bt) {
-            if (isset($bt['object']) and is_object($bt['object'])
+            if (isset($bt['object']) && is_object($bt['object'])
+                && (
+                    $bt['object'] instanceof advanced_testcase ||
+                    $bt['object'] instanceof database_driver_testcase)
+            ) {
+                $sinksupport = true;
+                break;
+            }
+        }
+        if (!$sinksupport) {
+            return false;
+        }
+
+        // Verify that we are inside a PHPUnit test (little bit redundant, because
+        // we already have checked above that this is an advanced/database_driver
+        // testcase, but let's keep things double safe for now).
+        foreach ($backtrace as $bt) {
+            if (isset($bt['object']) && is_object($bt['object'])
                     && $bt['object'] instanceof PHPUnit\Framework\TestCase) {
                 $debug = new stdClass();
                 $debug->message = $message;


### PR DESCRIPTION
The only tests that have COMPLETE* support for the debugging sink are the advanced_testcase and the database_driver ones (store and report). So we must ensure that the rest of tests don't use the debugging sink at all.

Right now we are using it for storing, but later there is not reporting, so any debugging happening within non advanced tests is not detected.

This commit just ensures that we stop making that storing for non advanced/database_driver tests. Nothing more, nothing less.

* Note that we have had to add a few missing bits to the database_driver testcase because it was not 100% complete. Now it behaves 100% the same than the advanced_testcase one regarding the debugging sink.

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.md guidelines for how to contribute patches for Moodle. Thank you.

--
